### PR TITLE
Implemented Fix For Guard Finding Hidden Slime

### DIFF
--- a/Slime Mall/Assets/Scripts/ActivatePrompt.cs
+++ b/Slime Mall/Assets/Scripts/ActivatePrompt.cs
@@ -49,22 +49,28 @@ public class ActivatePrompt : MonoBehaviour
 
     void OnTriggerEnter2D(Collider2D col)
     {
-        if (emotionResponse.activeSelf == false && onlyEmotion == false)
+        if (emotionResponse != null)
         {
-            if (col.CompareTag("PlayerArea"))
+            if (emotionResponse.activeSelf == false && onlyEmotion == false)
             {
-                prompt.SetActive(true);
+                if (col.CompareTag("PlayerArea"))
+                {
+                    prompt.SetActive(true);
+                }
             }
         }
     }
 
     void OnTriggerExit2D(Collider2D col)
     {
-        if (emotionResponse.activeSelf == false && onlyEmotion == false)
+        if (emotionResponse != null)
         {
-            if (col.CompareTag("PlayerArea"))
+            if (emotionResponse.activeSelf == false && onlyEmotion == false)
             {
-                prompt.SetActive(false);
+                if (col.CompareTag("PlayerArea"))
+                {
+                    prompt.SetActive(false);
+                }
             }
         }
     }

--- a/Slime Mall/Assets/Scripts/NPCs/SecurityBehaviour.cs
+++ b/Slime Mall/Assets/Scripts/NPCs/SecurityBehaviour.cs
@@ -67,10 +67,15 @@ public class SecurityBehaviour : NPCBehaviour
 
     public void OnCollisionEnter2D(Collision2D collision)
     {
-        if(collision.gameObject.GetComponent<PlayerController>())
+        PlayerController playerController;
+        collision.gameObject.TryGetComponent<PlayerController>(out playerController);
+        if(playerController)
         {
-            //Send off a call to game manager
-            GameManager.instance.CapturedEndGame();
+            if (playerController.IsSlimeHidden() == false)
+            {
+                //Send off a call to game manager
+                GameManager.instance.CapturedEndGame();
+            }
         }
     }
 }

--- a/Slime Mall/Assets/Scripts/PlayerController.cs
+++ b/Slime Mall/Assets/Scripts/PlayerController.cs
@@ -285,7 +285,7 @@ public class PlayerController : MonoBehaviour
     public void FreezePlayer()
     {
         isMovementEnabled = false;
-        GetComponent<Rigidbody2D>().constraints = RigidbodyConstraints2D.FreezePosition;
+        GetComponent<Rigidbody2D>().constraints = RigidbodyConstraints2D.FreezeAll;
     }
 
     private void UnFreezePlayer()


### PR DESCRIPTION
Security Guard now will check on collision with Slime whether or not they are actually hidden first and won't catch them if they are hidden.

Also fixed the unassigned reference exception from the ActivatePrompt script to do with the emotionResponse object not being assigned within the inspector.