### PR TITLE
Fixed Slime & Hide Spot Sprite Glitch On Kill

### DIFF
--- a/Slime Mall/Assets/Scripts/ActivatePrompt.cs
+++ b/Slime Mall/Assets/Scripts/ActivatePrompt.cs
@@ -34,17 +34,7 @@ public class ActivatePrompt : MonoBehaviour
 
     private void Update()
     {
-        //if(emotionResponse.activeSelf == true)
-        //{
-        //    if(CurrentTimeShowingEmotion > TimeToShowEmotion)
-        //    {
-        //        emotionResponse.SetActive(false);
-        //    }
-        //    else
-        //    {
-        //        CurrentTimeShowingEmotion += Time.deltaTime;
-        //    }
-        //}
+    
     }
 
     void OnTriggerEnter2D(Collider2D col)

--- a/Slime Mall/Assets/Scripts/NPCs/NPCBehaviour.cs
+++ b/Slime Mall/Assets/Scripts/NPCs/NPCBehaviour.cs
@@ -70,10 +70,13 @@ public class NPCBehaviour : MonoBehaviour
         {
             sight.UpdateSight(dir);
         }
-        UpdateStateMachine();
-
         animator.SetFloat("Horizontal", rb.velocity.normalized.x);
         animator.SetFloat("Vertical", rb.velocity.normalized.y);
+    }
+
+    private void FixedUpdate()
+    {
+        UpdateStateMachine();
     }
 
     public virtual void UpdateStateMachine()
@@ -82,7 +85,7 @@ public class NPCBehaviour : MonoBehaviour
         {
             case StateMachine.IDLE:
                 //Idle enough
-                    speed = 1.5f;
+                    speed = 1f;
                 if (CheckForSlime() == true)
                 {
                     GetComponent<ActivatePrompt>().ShowEmotion();
@@ -96,7 +99,7 @@ public class NPCBehaviour : MonoBehaviour
                 break;
 
             case StateMachine.WANDER:
-                    speed = 1.5f;
+                    speed = 1f;
                 MoveNPC(dir);
                 if (CheckForSlime() == true)
                 {
@@ -117,7 +120,7 @@ public class NPCBehaviour : MonoBehaviour
                 break;
             case StateMachine.ESCAPE:
                 const float runawayThresholdDistance = 7.5f;
-                    speed = 4;
+                    speed = 3;
                 if (Vector2.Distance(spottedSlime.transform.position, this.transform.position) >= runawayThresholdDistance)
                 {
                     GetComponent<ActivatePrompt>().HideEmotion();

--- a/Slime Mall/Assets/Scripts/NPCs/NPCSightComponent.cs
+++ b/Slime Mall/Assets/Scripts/NPCs/NPCSightComponent.cs
@@ -11,7 +11,7 @@ public class NPCSightComponent : MonoBehaviour
     List<GameObject> seenGameObjects;
 
     public LayerMask seeableObjectsLayer;
-    private float TimeToWaitToSee = 1.0f;
+    private float TimeToWaitToSee = 0.1f;
     private float CurrentWaitingTimeToSee = 0.0f;
     private Vector3 debugWireSpherePosition = Vector3.zero;
 

--- a/Slime Mall/Assets/Scripts/PlayerController.cs
+++ b/Slime Mall/Assets/Scripts/PlayerController.cs
@@ -113,10 +113,12 @@ public class PlayerController : MonoBehaviour
                 sr.flipX = true;
             else if (dir.x > 0)
                 sr.flipX = false;
-
-            ProcessInput();
-
         }
+    }
+
+    private void FixedUpdate()
+    {
+        ProcessInput();
     }
 
     void ProcessInput()
@@ -250,6 +252,11 @@ public class PlayerController : MonoBehaviour
 
     void DoKill(InputAction.CallbackContext obj)
     {
+        // If the slime is hiding don't let them kill an NPC
+        if(IsSlimeHidden() == true)
+        {
+            return;
+        }
         Collider2D[] colls = Physics2D.OverlapCircleAll(transform.position, interactRadius, interactLayer);
 
         foreach(Collider2D col in colls)


### PR DESCRIPTION
Preventing the Slime from killing while hidden will ensure we do not encounter this bug again. The movement code for player and NPC has been moved to FixedUpdate in order to prevent Time.deltaTime issues. Lastly the NPCSightComponent has had its' update frequency increased to ensure that the slime is actually caught if moves in front of the NPCs view.